### PR TITLE
Fix mobile navbar scroll

### DIFF
--- a/src/components/Custom/navbar/Navbar.js
+++ b/src/components/Custom/navbar/Navbar.js
@@ -28,6 +28,19 @@ function Navbar(props) {
     }
   };
 
+  const prevScrollY = useRef(window.scrollY);
+  const handleScroll = () => {
+    if (!lock) {
+      const currentY = window.scrollY;
+      if (currentY > prevScrollY.current) {
+        setHide(true);
+      } else if (currentY < prevScrollY.current) {
+        setHide(false);
+      }
+      prevScrollY.current = currentY;
+    }
+  };
+
   useEffect(() => {
     var hider;
     clearInterval(hider);
@@ -44,6 +57,11 @@ function Navbar(props) {
 
   useEffect(() => {
     window.addEventListener("wheel", wheel);
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("wheel", wheel);
+      window.removeEventListener("scroll", handleScroll);
+    };
   }, []);
   useEffect(() => {
     const handleResize = () => {


### PR DESCRIPTION
## Summary
- add scroll handler to close navbar on mobile

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npx react-scripts test --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684593c518a8832b89c72d62dc9c5c8d