### PR TITLE
Fix mobile menu hiding

### DIFF
--- a/src/components/Custom/navbar/Navbar.js
+++ b/src/components/Custom/navbar/Navbar.js
@@ -52,6 +52,9 @@ function Navbar(props) {
   }, [hide]);
 
   useEffect(() => {
+    if (hide) {
+      setMenuOpen(false);
+    }
     props.setNavbar(hide);
   }, [hide]);
 


### PR DESCRIPTION
## Summary
- close hamburger menu when navbar hides on scroll

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459592e410832bb1c5708267fd327e