### PR TITLE
Fix spin animation responsive size

### DIFF
--- a/src/components/SpinUp/SpinUp.js
+++ b/src/components/SpinUp/SpinUp.js
@@ -83,4 +83,9 @@ const Box = styled.div`
   background-position: center;
   /* border: 3px solid red; */
   transition: transform 3s ease, filter 3s, opacity 1s;
+
+  @media (max-width: 768px) {
+    width: calc(100% - 32px);
+    height: calc(100% - 32px);
+  }
 `;


### PR DESCRIPTION
## Summary
- adjust `SpinUp` box size in mobile via media query

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459fe23d04832bbfe4ae57cfb4b48a