### PR TITLE
Fix scroll reset bug

### DIFF
--- a/src/components/Custom/subProjects/ProjectsMini.js
+++ b/src/components/Custom/subProjects/ProjectsMini.js
@@ -52,7 +52,8 @@ function ProjectsMini(props) {
           id={id}
           onClick={() => {
             console.log("scrolling from project blocks mini");
-            console.log((document.getElementById(id).scroll = -1000));
+            const el = document.getElementById(id);
+            if (el) el.scrollTop = 0;
           }}
         >
           <div>


### PR DESCRIPTION
## Summary
- clean up scroll handler so ProjectsMini no longer overrides the DOM `scroll` method

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afc1cbdec832b958e83bb4c961ddb