### PR TITLE
Disable pointer events while scrolling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,28 @@ import "./App.css";
 
 function App() {
   const [navbar, setNavbar] = useState(false);
-  useEffect(() => {}, []);
+
+  // Disable pointer events while the user is actively scrolling to
+  // prevent hover animations from causing jitters. Pointer events are
+  // re-enabled shortly after scrolling stops (debounced).
+  useEffect(() => {
+    let timer;
+    const disablePointer = () => {
+      document.body.style.pointerEvents = "none";
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        document.body.style.pointerEvents = "";
+      }, 150);
+    };
+
+    window.addEventListener("scroll", disablePointer, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", disablePointer);
+      clearTimeout(timer);
+      document.body.style.pointerEvents = "";
+    };
+  }, []);
+
   const dispId = uuidv4;
   return (
     <div>


### PR DESCRIPTION
## Summary
- prevent hover animations from firing while scrolling by disabling pointer events on the body

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed67ceb50832b89684ab3e482b856